### PR TITLE
chore: remove laravel/pulse dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "laravel/horizon": "^5.33",
         "laravel/nightwatch": "^1.11",
         "laravel/octane": "^2.12",
-        "laravel/pulse": "^1.4",
         "laravel/reverb": "^1.5",
         "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1",


### PR DESCRIPTION
- Removed "laravel/pulse" version 1.4 from composer.json as it is no longer needed for the project.