### PR TITLE
chore: remove laravel/reverb dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "laravel/horizon": "^5.33",
         "laravel/nightwatch": "^1.11",
         "laravel/octane": "^2.12",
-        "laravel/reverb": "^1.5",
         "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1",
         "laravel/wayfinder": "^0.1.6",


### PR DESCRIPTION
- Removed "laravel/reverb" version 1.5 from composer.json as it is no longer needed for the project.