### PR TITLE
chore: remove laravel/wayfinder dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "laravel/octane": "^2.12",
         "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1",
-        "laravel/wayfinder": "^0.1.6",
         "tightenco/ziggy": "^2.4"
     },
     "require-dev": {


### PR DESCRIPTION
- Removed "laravel/wayfinder" version 0.1.6 from composer.json as it is no longer needed for the project.