### PR TITLE
feat: enhance user and company models with relationships and factories

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,9 +4,12 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Modules\Lumasachi\app\Models\Company;
 use Modules\Lumasachi\app\Models\Order;
 use Modules\Lumasachi\app\Enums\UserRole;
 use Modules\Lumasachi\app\Enums\UserType;
@@ -31,8 +34,7 @@ class User extends Authenticatable
         'password',
         'role',
         'phone_number',
-        'address',
-        'company',
+        'company_id',
         'is_active',
         'notes',
         'type',
@@ -46,7 +48,9 @@ class User extends Authenticatable
      */
     protected $attributes = [
         'role' => UserRole::EMPLOYEE,
+        'is_active' => false,
         'type' => UserType::INDIVIDUAL,
+        'company_id' => null,
     ];
 
     /**
@@ -109,22 +113,27 @@ class User extends Authenticatable
     // Accessors
     public function getFullNameAttribute(): string
     {
-        return $this->first_name . ' ' . $this->last_name;
+        return $this->first_name . " " . $this->last_name;
     }
 
     // Relationships
-    public function createdOrders()
+    public function createdOrders(): HasMany
     {
         return $this->hasMany(Order::class, 'created_by');
     }
 
-    public function assignedOrders()
+    public function assignedOrders(): HasMany
     {
         return $this->hasMany(Order::class, 'assigned_to');
     }
 
-    public function customerOrders()
+    public function customerOrders(): HasMany
     {
         return $this->hasMany(Order::class, 'customer_id');
+    }
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class, 'company_id', 'uuid');
     }
 }

--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Company>
+ */
+class CompanyFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->company(),
+            'email' => fake()->unique()->companyEmail(),
+            'phone' => fake()->phoneNumber(),
+            'address' => fake()->streetAddress(),
+            'city' => fake()->city(),
+            'state' => fake()->state(),
+            'postal_code' => fake()->postcode(),
+            'country' => fake()->country(),
+            'description' => fake()->paragraph(),
+            'website' => fake()->url(),
+            'logo' => fake()->imageUrl(200, 200, 'business'),
+            'is_active' => fake()->boolean(90), // 90% chance of being active
+            'tax_id' => fake()->numerify('##-#######'),
+            'contact_person' => fake()->name(),
+            'contact_email' => fake()->safeEmail(),
+            'contact_phone' => fake()->phoneNumber(),
+            'notes' => fake()->optional()->text(200),
+            'settings' => [
+                'theme' => fake()->randomElement(['light', 'dark', 'auto']),
+                'notifications' => fake()->boolean(),
+                'timezone' => fake()->timezone(),
+                'language' => fake()->randomElement(['en', 'es', 'fr', 'de']),
+            ],
+        ];
+    }
+
+    /**
+     * Indicate that the company is inactive.
+     */
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => false,
+        ]);
+    }
+
+    /**
+     * Indicate that the company is active.
+     */
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => true,
+        ]);
+    }
+
+    /**
+     * Indicate that the company has no website.
+     */
+    public function withoutWebsite(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'website' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the company has no logo.
+     */
+    public function withoutLogo(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'logo' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the company has minimal information.
+     */
+    public function minimal(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'description' => null,
+            'website' => null,
+            'logo' => null,
+            'tax_id' => null,
+            'contact_person' => null,
+            'contact_email' => null,
+            'contact_phone' => null,
+            'notes' => null,
+            'settings' => null,
+        ]);
+    }
+
+    /**
+     * Configure the factory to create a company with complete information.
+     */
+    public function complete(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'description' => fake()->paragraphs(3, true),
+            'notes' => fake()->paragraphs(2, true),
+            'settings' => [
+                'theme' => fake()->randomElement(['light', 'dark', 'auto']),
+                'notifications' => fake()->boolean(),
+                'timezone' => fake()->timezone(),
+                'language' => fake()->randomElement(['en', 'es', 'fr', 'de']),
+                'currency' => fake()->currencyCode(),
+                'date_format' => fake()->randomElement(['Y-m-d', 'd/m/Y', 'm/d/Y']),
+                'time_format' => fake()->randomElement(['H:i', 'h:i A']),
+            ],
+        ]);
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -33,8 +33,6 @@ class UserFactory extends Factory
             'password' => static::$password ??= Hash::make('password'),
             'role' => fake()->randomElement(UserRole::cases()),
             'phone_number' => fake()->phoneNumber(),
-            'address' => fake()->address(),
-            'company' => fake()->company(),
             'is_active' => fake()->boolean(),
             'notes' => fake()->text(),
             'type' => fake()->randomElement(UserType::getTypes()),

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -14,6 +14,11 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id()->unsigned();
+            $table->foreignUuid('company_id')
+                ->nullable()
+                ->constrained('companies', 'uuid')
+                ->nullOnDelete()
+                ->cascadeOnUpdate();
             $table->string('first_name');
             $table->string('last_name');
             $table->string('email')->unique();
@@ -21,8 +26,6 @@ return new class extends Migration
             $table->string('password');
             $table->enum('role', array_column(UserRole::cases(), 'value'))->default(UserRole::EMPLOYEE->value);
             $table->string('phone_number')->nullable();
-            $table->string('address')->nullable();
-            $table->string('company')->nullable();
             $table->boolean('is_active');
             $table->text('notes')->nullable();
             $table->string('type')->nullable();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,10 +13,12 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+
         // User::factory(10)->create();
 
         User::factory()->create([
-            'name' => 'Test User',
+            'first_name' => 'Test',
+            'last_name' => 'User',
             'email' => 'test@example.com',
         ]);
     }

--- a/modules/Lumasachi/app/Http/Controllers/OrderHistoryController.php
+++ b/modules/Lumasachi/app/Http/Controllers/OrderHistoryController.php
@@ -64,7 +64,7 @@ final class OrderHistoryController extends Controller
     /**
      * Display the specified order history.
      */
-    public function show(Request $request, OrderHistory $orderHistory): JsonResponse
+    public function show(OrderHistory $orderHistory): JsonResponse
     {
         Gate::authorize('view', $orderHistory);
 
@@ -76,7 +76,7 @@ final class OrderHistoryController extends Controller
     /**
      * Remove the specified order history.
      */
-    public function destroy(Request $request, OrderHistory $orderHistory): JsonResponse
+    public function destroy(OrderHistory $orderHistory): JsonResponse
     {
         Gate::authorize('delete', $orderHistory);
 
@@ -88,7 +88,7 @@ final class OrderHistoryController extends Controller
     /**
      * Get the order associated with this history entry.
      */
-    public function order(Request $request, OrderHistory $orderHistory, Order $order): JsonResponse
+    public function order(OrderHistory $orderHistory, Order $order): JsonResponse
     {
         Gate::authorize('view', $orderHistory);
 
@@ -98,6 +98,9 @@ final class OrderHistoryController extends Controller
                 'message' => 'Order history does not belong to the specified order.'
             ], Response::HTTP_NOT_FOUND);
         }
+
+        // Load the order relationship if not already loaded
+        $orderHistory->loadMissing('order');
 
         return response()->json([
             'order' => new \Modules\Lumasachi\app\Http\Resources\OrderResource($orderHistory->order)
@@ -107,7 +110,7 @@ final class OrderHistoryController extends Controller
     /**
      * Get attachments for the order associated with this history entry.
      */
-    public function orderAttachments(Request $request, OrderHistory $orderHistory, Order $order): JsonResponse
+    public function orderAttachments(OrderHistory $orderHistory, Order $order): JsonResponse
     {
         Gate::authorize('view', $orderHistory);
 
@@ -117,6 +120,9 @@ final class OrderHistoryController extends Controller
                 'message' => 'Order history does not belong to the specified order.'
             ], Response::HTTP_NOT_FOUND);
         }
+
+        // Load the order relationship with attachments if not already loaded
+        $orderHistory->loadMissing(['order.attachments']);
 
         $attachments = $orderHistory->order->attachments;
 

--- a/modules/Lumasachi/app/Models/Company.php
+++ b/modules/Lumasachi/app/Models/Company.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Modules\Lumasachi\app\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Modules\Lumasachi\database\factories\CompanyFactory;
+use App\Models\User;
+
+class Company extends Model
+{
+    use HasFactory, HasUuids;
+
+    /**
+     * The primary key associated with the table.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'uuid';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The data type of the primary key.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'companies';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'address',
+        'city',
+        'state',
+        'postal_code',
+        'country',
+        'description',
+        'website',
+        'logo',
+        'is_active',
+        'tax_id',
+        'contact_person',
+        'contact_email',
+        'contact_phone',
+        'notes',
+        'settings',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'is_active' => 'boolean',
+        'settings' => 'json',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * The attributes that should have default values.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'is_active' => true,
+    ];
+
+    /**
+     * Get all users that belong to this company.
+     */
+    public function users()
+    {
+        return $this->hasMany(\App\Models\User::class, 'company_id', 'uuid');
+    }
+
+    /**
+     * Get all active users that belong to this company.
+     */
+    public function activeUsers()
+    {
+        return $this->hasMany(\App\Models\User::class, 'company_id', 'uuid')->where('is_active', true);
+    }
+
+    /**
+     * Scope a query to only include active companies.
+     */
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+
+    /**
+     * Scope a query to only include inactive companies.
+     */
+    public function scopeInactive($query)
+    {
+        return $query->where('is_active', false);
+    }
+
+    /**
+     * Get the full address of the company.
+     */
+    public function getFullAddressAttribute(): string
+    {
+        $parts = array_filter([
+            $this->address,
+            $this->city,
+            $this->state,
+            $this->postal_code,
+            $this->country,
+        ]);
+
+        return implode(', ', $parts);
+    }
+
+    /**
+     * Get the columns that should receive a unique identifier.
+     *
+     * @return array
+     */
+    public function uniqueIds(): array
+    {
+        return ['uuid'];
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
+     */
+    protected static function newFactory()
+    {
+        return CompanyFactory::new();
+    }
+}
+

--- a/modules/Lumasachi/app/Models/OrderHistory.php
+++ b/modules/Lumasachi/app/Models/OrderHistory.php
@@ -53,4 +53,14 @@ class OrderHistory extends Model
     public function createdBy(): BelongsTo {
         return $this->belongsTo(User::class, 'created_by');
     }
+
+    /**
+     * Get the order(s) related to this order history.
+     * This is an alias for the order() method to maintain compatibility.
+     *
+     * @return BelongsTo
+     */
+    public function orders(): BelongsTo {
+        return $this->order();
+    }
 }

--- a/modules/Lumasachi/database/factories/AttachmentFactory.php
+++ b/modules/Lumasachi/database/factories/AttachmentFactory.php
@@ -73,8 +73,8 @@ final class AttachmentFactory extends Factory
         $extension = $this->faker->randomElement($fileType['extensions']);
         $mimeType = $this->faker->randomElement($fileType['mimeTypes']);
 
-        // Generate file name
-        $fileName = $this->faker->word() . '_' . time() . '.' . $extension;
+        // Generate file name with unique identifier
+        $fileName = $this->faker->word() . '_' . time() . '_' . $this->faker->unique()->randomNumber(5) . '.' . $extension;
 
         // Generate file path (simulating folder structure)
         $year = date('Y');
@@ -105,7 +105,7 @@ final class AttachmentFactory extends Factory
         return $this->state(function (array $attributes) {
             $extension = $this->faker->randomElement(['jpg', 'png', 'gif', 'webp']);
             $mimeType = $this->faker->randomElement(Attachment::IMAGE_MIME_TYPES);
-            $fileName = $this->faker->word() . '_' . time() . '.' . $extension;
+            $fileName = $this->faker->word() . '_' . time() . '_' . $this->faker->unique()->randomNumber(5) . '.' . $extension;
             $year = date('Y');
             $month = date('m');
 
@@ -124,7 +124,7 @@ final class AttachmentFactory extends Factory
     public function pdf(): static
     {
         return $this->state(function (array $attributes) {
-            $fileName = $this->faker->word() . '_document_' . time() . '.pdf';
+            $fileName = $this->faker->word() . '_document_' . time() . '_' . $this->faker->unique()->randomNumber(5) . '.pdf';
             $year = date('Y');
             $month = date('m');
 
@@ -150,7 +150,7 @@ final class AttachmentFactory extends Factory
             ];
 
             $type = $this->faker->randomElement($types);
-            $fileName = $this->faker->word() . '_' . time() . '.' . $type['ext'];
+            $fileName = $this->faker->word() . '_' . time() . '_' . $this->faker->unique()->randomNumber(5) . '.' . $type['ext'];
             $year = date('Y');
             $month = date('m');
 
@@ -176,7 +176,7 @@ final class AttachmentFactory extends Factory
             ];
 
             $type = $this->faker->randomElement($types);
-            $fileName = $this->faker->word() . '_data_' . time() . '.' . $type['ext'];
+            $fileName = $this->faker->word() . '_data_' . time() . '_' . $this->faker->unique()->randomNumber(5) . '.' . $type['ext'];
             $year = date('Y');
             $month = date('m');
 

--- a/modules/Lumasachi/database/factories/CompanyFactory.php
+++ b/modules/Lumasachi/database/factories/CompanyFactory.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Modules\Lumasachi\database\factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Modules\Lumasachi\app\Models\Company>
+ */
+class CompanyFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = \Modules\Lumasachi\app\Models\Company::class;
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->company(),
+            'email' => fake()->unique()->companyEmail(),
+            'phone' => fake()->phoneNumber(),
+            'address' => fake()->streetAddress(),
+            'city' => fake()->city(),
+            'state' => fake()->state(),
+            'postal_code' => fake()->postcode(),
+            'country' => fake()->country(),
+            'description' => fake()->optional(0.8)->paragraph(), // 80% chance of having description
+            'website' => fake()->optional(0.7)->url(), // 70% chance of having website
+            'logo' => fake()->optional(0.6)->imageUrl(200, 200, 'business'), // 60% chance of having logo
+            'is_active' => fake()->boolean(90), // 90% chance of being active
+            'tax_id' => fake()->optional(0.7)->numerify('##-#######'), // 70% chance of having tax_id
+            'contact_person' => fake()->optional(0.8)->name(), // 80% chance of having contact person
+            'contact_email' => fake()->optional(0.8)->safeEmail(), // 80% chance of having contact email
+            'contact_phone' => fake()->optional(0.8)->phoneNumber(), // 80% chance of having contact phone
+            'notes' => fake()->optional(0.5)->text(200), // 50% chance of having notes
+            'settings' => fake()->optional(0.9)->passthrough([
+                'theme' => fake()->randomElement(['light', 'dark', 'auto']),
+                'notifications' => fake()->boolean(),
+                'timezone' => fake()->timezone(),
+                'language' => fake()->randomElement(['en', 'es', 'fr', 'de']),
+            ]), // 90% chance of having settings
+        ];
+    }
+
+    /**
+     * Indicate that the company is inactive.
+     */
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => false,
+        ]);
+    }
+
+    /**
+     * Indicate that the company is active.
+     */
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => true,
+        ]);
+    }
+
+    /**
+     * Indicate that the company has no website.
+     */
+    public function withoutWebsite(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'website' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the company has no logo.
+     */
+    public function withoutLogo(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'logo' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the company has minimal information.
+     */
+    public function minimal(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'description' => null,
+            'website' => null,
+            'logo' => null,
+            'tax_id' => null,
+            'contact_person' => null,
+            'contact_email' => null,
+            'contact_phone' => null,
+            'notes' => null,
+            'settings' => null,
+        ]);
+    }
+
+    /**
+     * Configure the factory to create a company with complete information.
+     */
+    public function complete(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'description' => fake()->paragraphs(3, true),
+            'notes' => fake()->paragraphs(2, true),
+            'settings' => [
+                'theme' => fake()->randomElement(['light', 'dark', 'auto']),
+                'notifications' => fake()->boolean(),
+                'timezone' => fake()->timezone(),
+                'language' => fake()->randomElement(['en', 'es', 'fr', 'de']),
+                'currency' => fake()->currencyCode(),
+                'date_format' => fake()->randomElement(['Y-m-d', 'd/m/Y', 'm/d/Y']),
+                'time_format' => fake()->randomElement(['H:i', 'h:i A']),
+            ],
+        ]);
+    }
+}

--- a/modules/Lumasachi/database/migrations/0000_01_01_000000_create_company_table.php
+++ b/modules/Lumasachi/database/migrations/0000_01_01_000000_create_company_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('companies', function (Blueprint $table) {
+            $table->uuid('uuid')->primary();
+            $table->string('name');
+            $table->string('email');
+            $table->string('phone');
+            $table->string('address');
+            $table->string('city');
+            $table->string('state');
+            $table->string('postal_code');
+            $table->string('country');
+            $table->string('website')->nullable();
+            $table->string('logo')->nullable();
+            $table->string('tax_id')->nullable();
+            $table->string('contact_person')->nullable();
+            $table->string('contact_email')->nullable();
+            $table->string('contact_phone')->nullable();
+            $table->text('notes')->nullable();
+            $table->json('settings')->nullable();
+            $table->text('description')->nullable();
+            $table->boolean('is_active');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('companies');
+    }
+};

--- a/modules/Lumasachi/database/migrations/2025_07_27_164818_create_orders_table.php
+++ b/modules/Lumasachi/database/migrations/2025_07_27_164818_create_orders_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
         Schema::create('orders', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->foreignId('customer_id')
+                ->index()
                 ->constrained('users')
                 ->cascadeOnUpdate()
                 ->nullOnDelete();

--- a/modules/Lumasachi/database/seeders/CompanySeeder.php
+++ b/modules/Lumasachi/database/seeders/CompanySeeder.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Modules\Lumasachi\database\seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+use Modules\Lumasachi\app\Models\Company;
+use Faker\Factory as Faker;
+
+class CompanySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $faker = Faker::create();
+
+        $companies = [
+            [
+                'uuid' => Str::uuid(),
+                'name' => 'Acme Corporation',
+                'description' => 'A leading provider of innovative solutions and services.',
+                'phone' => $faker->phoneNumber(),
+                'address' => '123 Main Street, Suite 100',
+                'city' => 'New York',
+                'state' => 'NY',
+                'postal_code' => '10001',
+                'country' => 'USA',
+                'email' => 'info@acmecorp.com',
+                'contact_person' => 'John Doe',
+                'contact_email' => 'john.doe@acmecorp.com',
+                'contact_phone' => $faker->phoneNumber(),
+                'is_active' => true,
+            ],
+            [
+                'uuid' => Str::uuid(),
+                'name' => 'TechVentures Inc.',
+                'description' => 'Specializing in cutting-edge technology and software development.',
+                'phone' => $faker->phoneNumber(),
+                'address' => '456 Innovation Drive',
+                'city' => 'San Francisco',
+                'state' => 'CA',
+                'postal_code' => '94105',
+                'country' => 'USA',
+                'email' => 'contact@techventures.com',
+                'contact_person' => 'Jane Smith',
+                'contact_email' => 'jane.smith@techventures.com',
+                'contact_phone' => $faker->phoneNumber(),
+                'is_active' => true,
+            ],
+            [
+                'uuid' => Str::uuid(),
+                'name' => 'Global Solutions Ltd.',
+                'description' => 'International consulting and business services.',
+                'phone' => $faker->phoneNumber(),
+                'address' => '789 Business Park Avenue',
+                'city' => 'London',
+                'state' => 'England',
+                'postal_code' => 'EC2A 4NE',
+                'country' => 'UK',
+                'email' => 'hello@globalsolutions.com',
+                'contact_person' => 'Robert Johnson',
+                'contact_email' => 'robert.johnson@globalsolutions.com',
+                'contact_phone' => $faker->phoneNumber(),
+                'is_active' => true,
+            ],
+            [
+                'uuid' => Str::uuid(),
+                'name' => 'StartUp Hub',
+                'description' => 'Incubator and accelerator for emerging businesses.',
+                'phone' => $faker->phoneNumber(),
+                'address' => '321 Entrepreneur Lane',
+                'city' => 'Austin',
+                'state' => 'TX',
+                'postal_code' => '78701',
+                'country' => 'USA',
+                'email' => 'info@startuphub.io',
+                'contact_person' => 'Sarah Williams',
+                'contact_email' => 'sarah.williams@startuphub.io',
+                'contact_phone' => $faker->phoneNumber(),
+                'is_active' => true,
+            ],
+            [
+                'uuid' => Str::uuid(),
+                'name' => 'Legacy Enterprises',
+                'description' => 'Traditional business with modern approach.',
+                'phone' => $faker->phoneNumber(),
+                'address' => '555 Heritage Boulevard',
+                'city' => 'Chicago',
+                'state' => 'IL',
+                'postal_code' => '60601',
+                'country' => 'USA',
+                'email' => 'contact@legacyenterprises.com',
+                'contact_person' => 'Michael Brown',
+                'contact_email' => 'michael.brown@legacyenterprises.com',
+                'contact_phone' => $faker->phoneNumber(),
+                'is_active' => false, // Example of inactive company
+            ],
+        ];
+
+        foreach ($companies as $company) {
+            Company::create($company);
+        }
+    }
+}
+

--- a/modules/Lumasachi/database/seeders/DatabaseSeeder.php
+++ b/modules/Lumasachi/database/seeders/DatabaseSeeder.php
@@ -11,6 +11,7 @@ use Modules\Lumasachi\app\Enums\UserRole;
 use Modules\Lumasachi\app\Enums\UserType;
 use Modules\Lumasachi\app\Enums\OrderStatus;
 use Modules\Lumasachi\app\Enums\OrderPriority;
+use Modules\Lumasachi\database\seeders\CompanySeeder;
 use Carbon\Carbon;
 
 final class DatabaseSeeder extends Seeder
@@ -20,6 +21,9 @@ final class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        // Seed companies first
+        $this->call(CompanySeeder::class);
+
         // Create Super Administrator
         $superAdmin = User::factory()->create([
             'first_name' => 'Super',
@@ -93,7 +97,6 @@ final class DatabaseSeeder extends Seeder
             'role' => UserRole::CUSTOMER,
             'type' => UserType::INDIVIDUAL,
             'phone_number' => '+1234567896',
-            'address' => '123 Main St, New York, NY 10001',
             'is_active' => true,
         ]);
 
@@ -104,7 +107,6 @@ final class DatabaseSeeder extends Seeder
             'role' => UserRole::CUSTOMER,
             'type' => UserType::INDIVIDUAL,
             'phone_number' => '+1234567897',
-            'address' => '456 Oak Ave, Los Angeles, CA 90001',
             'is_active' => true,
         ]);
 
@@ -115,9 +117,7 @@ final class DatabaseSeeder extends Seeder
             'email' => 'robert@techcorp.com',
             'role' => UserRole::CUSTOMER,
             'type' => UserType::BUSINESS,
-            'company' => 'Tech Corp Solutions',
             'phone_number' => '+1234567898',
-            'address' => '789 Business Blvd, San Francisco, CA 94105',
             'is_active' => true,
             'notes' => 'VIP customer - priority service',
         ]);
@@ -128,9 +128,7 @@ final class DatabaseSeeder extends Seeder
             'email' => 'sarah@designstudio.com',
             'role' => UserRole::CUSTOMER,
             'type' => UserType::BUSINESS,
-            'company' => 'Creative Design Studio',
             'phone_number' => '+1234567899',
-            'address' => '321 Art District, Chicago, IL 60601',
             'is_active' => true,
         ]);
 

--- a/modules/Lumasachi/routes/api.php
+++ b/modules/Lumasachi/routes/api.php
@@ -84,8 +84,8 @@ Route::group(['prefix' => 'v1'], function () {
         return $user->createToken($request->device_name)->plainTextToken;
     });
 
-    // Order Routes
-    Route::middleware('auth:sanctum')->prefix('history')->group(function () {
+    // Order History Routes
+    Route::scopeBindings()->middleware('auth:sanctum')->prefix('history')->group(function () {
         Route::get('/', [OrderHistoryController::class, 'index'])->middleware('can:viewAny,Modules\Lumasachi\app\Models\OrderHistory');
         Route::post('/', [OrderHistoryController::class, 'store'])->middleware('can:create,Modules\Lumasachi\app\Models\OrderHistory');
         Route::get('/{orderHistory}', [OrderHistoryController::class, 'show'])->middleware('can:view,orderHistory');
@@ -96,7 +96,7 @@ Route::group(['prefix' => 'v1'], function () {
     });
 
     // Order Routes
-    Route::middleware('auth:sanctum')->prefix('orders')->group(function () {
+    Route::scopeBindings()->middleware('auth:sanctum')->prefix('orders')->group(function () {
         Route::get('/', [OrderController::class, 'index'])->middleware('can:viewAny,Modules\Lumasachi\app\Models\Order');
         Route::post('/', [OrderController::class, 'store'])->middleware('can:create,Modules\Lumasachi\app\Models\Order');
         Route::get('/{order}', [OrderController::class, 'show'])->middleware('can:view,order');
@@ -111,7 +111,7 @@ Route::group(['prefix' => 'v1'], function () {
     });
 
     // Attachment Routes (outside of orders prefix)
-    Route::middleware('auth:sanctum')->prefix('attachments')->group(function () {
+    Route::scopeBindings()->middleware('auth:sanctum')->prefix('attachments')->group(function () {
         Route::get('/{attachment}/download', [AttachmentController::class, 'download'])
             ->name('attachments.download');
         Route::get('/{attachment}/preview', [AttachmentController::class, 'preview'])

--- a/modules/Lumasachi/tests/Feature/app/Models/CompanyTest.php
+++ b/modules/Lumasachi/tests/Feature/app/Models/CompanyTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature;
+
+use Modules\Lumasachi\app\Models\Company;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompanyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test company creation.
+     *
+     * @return void
+     */
+    public function test_create_company()
+    {
+        $companyData = [
+            'name' => 'Test Company',
+            'email' => 'test@example.com',
+            'phone' => '1234567890',
+            'address' => '123 Test Street',
+            'city' => 'Test City',
+            'state' => 'Test State',
+            'postal_code' => '12345',
+            'country' => 'Test Country',
+            'website' => 'http://www.test.com',
+            'description' => 'A test company',
+            'is_active' => true,
+            'contact_person' => 'John Doe',
+            'contact_email' => 'john@example.com',
+            'contact_phone' => '9876543210',
+        ];
+
+        $company = Company::create($companyData);
+
+        $this->assertInstanceOf(Company::class, $company);
+        $this->assertEquals('Test Company', $company->name);
+        $this->assertEquals('test@example.com', $company->email);
+        $this->assertTrue($company->is_active);
+        $this->assertDatabaseHas('companies', [
+            'name' => 'Test Company',
+            'email' => 'test@example.com'
+        ]);
+    }
+
+    /**
+     * Test company retrieval.
+     *
+     * @return void
+     */
+    public function test_read_company()
+    {
+        $company = Company::factory()->create();
+
+        // Test finding by UUID
+        $foundCompany = Company::find($company->uuid);
+        
+        $this->assertInstanceOf(Company::class, $foundCompany);
+        $this->assertEquals($company->uuid, $foundCompany->uuid);
+        $this->assertEquals($company->name, $foundCompany->name);
+        $this->assertEquals($company->email, $foundCompany->email);
+    }
+
+    /**
+     * Test company update.
+     *
+     * @return void
+     */
+    public function test_update_company()
+    {
+        $company = Company::factory()->create([
+            'name' => 'Original Name'
+        ]);
+
+        // Update the company
+        $company->update([
+            'name' => 'Updated Name',
+            'description' => 'Updated description'
+        ]);
+
+        // Refresh the model to get the latest data
+        $company->refresh();
+
+        $this->assertEquals('Updated Name', $company->name);
+        $this->assertEquals('Updated description', $company->description);
+        $this->assertDatabaseHas('companies', [
+            'uuid' => $company->uuid,
+            'name' => 'Updated Name'
+        ]);
+    }
+
+    /**
+     * Test company deletion.
+     *
+     * @return void
+     */
+    public function test_delete_company()
+    {
+        $company = Company::factory()->create();
+        $companyUuid = $company->uuid;
+
+        // Delete the company
+        $company->delete();
+
+        // Verify it's deleted from database
+        $this->assertDatabaseMissing('companies', ['uuid' => $companyUuid]);
+        
+        // Try to find the deleted company
+        $deletedCompany = Company::find($companyUuid);
+        $this->assertNull($deletedCompany);
+    }
+}
+

--- a/modules/Lumasachi/tests/Feature/app/Policies/UserPolicyTest.php
+++ b/modules/Lumasachi/tests/Feature/app/Policies/UserPolicyTest.php
@@ -7,7 +7,9 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\User;
 use Modules\Lumasachi\app\Enums\UserRole;
 use Modules\Lumasachi\app\Enums\UserType;
+use Modules\Lumasachi\app\Models\Company;
 use Modules\Lumasachi\database\seeders\DatabaseSeeder;
+use PHPUnit\Framework\Attributes\Test;
 
 final class UserPolicyTest extends TestCase
 {
@@ -23,7 +25,8 @@ final class UserPolicyTest extends TestCase
     /**
      * Test viewAny users permissions.
      */
-    public function test_view_any_users_permissions()
+    #[Test]
+    public function it_can_view_any_users_permissions()
     {
         $superAdmin = User::where('role', UserRole::SUPER_ADMINISTRATOR)->first();
         $admin = User::where('role', UserRole::ADMINISTRATOR)->first();
@@ -42,7 +45,8 @@ final class UserPolicyTest extends TestCase
     /**
      * Test view specific user permissions.
      */
-    public function test_view_specific_user_permissions()
+    #[Test]
+    public function it_can_view_specific_user_permissions()
     {
         $superAdmin = User::where('role', UserRole::SUPER_ADMINISTRATOR)->first();
         $admin = User::where('role', UserRole::ADMINISTRATOR)->first();
@@ -79,7 +83,8 @@ final class UserPolicyTest extends TestCase
     /**
      * Test create user permissions.
      */
-    public function test_create_user_permissions()
+    #[Test]
+    public function it_can_create_user_permissions()
     {
         $superAdmin = User::where('role', UserRole::SUPER_ADMINISTRATOR)->first();
         $admin = User::where('role', UserRole::ADMINISTRATOR)->first();
@@ -98,7 +103,8 @@ final class UserPolicyTest extends TestCase
     /**
      * Test update user permissions.
      */
-    public function test_update_user_permissions()
+    #[Test]
+    public function it_can_update_user_permissions()
     {
         $superAdmin = User::where('role', UserRole::SUPER_ADMINISTRATOR)->first();
         $admin = User::where('role', UserRole::ADMINISTRATOR)->first();
@@ -131,9 +137,11 @@ final class UserPolicyTest extends TestCase
     }
 
     /**
+     *
      * Test delete user permissions.
      */
-    public function test_delete_user_permissions()
+    #[Test]
+    public function it_can_delete_user_permissions()
     {
         $superAdmin = User::where('role', UserRole::SUPER_ADMINISTRATOR)->first();
         $admin = User::where('role', UserRole::ADMINISTRATOR)->first();
@@ -169,7 +177,8 @@ final class UserPolicyTest extends TestCase
     /**
      * Test edge cases with inactive users.
      */
-    public function test_permissions_with_inactive_users()
+    #[Test]
+    public function it_can_permissions_with_inactive_users()
     {
         $admin = User::where('role', UserRole::ADMINISTRATOR)->first();
         $activeEmployee = User::where('role', UserRole::EMPLOYEE)->where('is_active', true)->first();
@@ -194,7 +203,8 @@ final class UserPolicyTest extends TestCase
     /**
      * Test permissions with different user types (Individual vs Business).
      */
-    public function test_permissions_with_user_types()
+    #[Test]
+    public function it_can_permissions_with_user_types()
     {
         $admin = User::where('role', UserRole::ADMINISTRATOR)->first();
         $individualCustomer = User::where('role', UserRole::CUSTOMER)

--- a/modules/Lumasachi/tests/Unit/app/Models/CompanyTest.php
+++ b/modules/Lumasachi/tests/Unit/app/Models/CompanyTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Modules\Lumasachi\Tests\Unit\app\Models;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Modules\Lumasachi\app\Models\Company;
+
+final class CompanyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that Company model uses required traits.
+     */
+    public function test_company_uses_required_traits(): void
+    {
+        $company = new Company();
+
+        // Check for HasFactory trait
+        $this->assertTrue(method_exists($company, 'factory'));
+    }
+
+    /**
+     * Test that fillable attributes are set correctly.
+     */
+    public function test_fillable_attributes(): void
+    {
+        $company = new Company();
+        $fillable = $company->getFillable();
+
+        $expectedFillable = [
+            'name',
+            'email',
+            'phone',
+            'address',
+            'city',
+            'state',
+            'postal_code',
+            'country',
+            'description',
+            'website',
+            'logo',
+            'is_active',
+            'tax_id',
+            'contact_person',
+            'contact_email',
+            'contact_phone',
+            'notes',
+            'settings',
+        ];
+
+        $this->assertEquals($expectedFillable, $fillable);
+    }
+
+    /**
+     * Test that casts are set correctly.
+     */
+    public function test_casts_attributes(): void
+    {
+        $company = new Company();
+        $casts = $company->getCasts();
+
+        $this->assertArrayHasKey('is_active', $casts);
+        $this->assertArrayHasKey('settings', $casts);
+        $this->assertArrayHasKey('created_at', $casts);
+        $this->assertArrayHasKey('updated_at', $casts);
+
+        $this->assertEquals('boolean', $casts['is_active']);
+        $this->assertEquals('json', $casts['settings']);
+        $this->assertStringContainsString('datetime', $casts['created_at']);
+        $this->assertStringContainsString('datetime', $casts['updated_at']);
+    }
+
+    /**
+     * Test model table name.
+     */
+    public function test_model_table_name(): void
+    {
+        $company = new Company();
+
+        $this->assertEquals('companies', $company->getTable());
+    }
+
+    /**
+     * Test users relationship.
+     */
+    public function test_users_relationship(): void
+    {
+        $company = Company::factory()->create();
+
+        $users = \App\Models\User::factory()->count(3)->create(['company_id' => $company->uuid]);
+
+        $this->assertCount(3, $company->users);
+        $this->assertEquals($users->pluck('id')->toArray(), $company->users->pluck('id')->toArray());
+    }
+
+    /**
+     * Test activeUsers relationship.
+     */
+    public function test_active_users_relationship(): void
+    {
+        $company = Company::factory()->create();
+
+        \App\Models\User::factory()->count(2)->create(['company_id' => $company->uuid, 'is_active' => true]);
+        \App\Models\User::factory()->count(1)->create(['company_id' => $company->uuid, 'is_active' => false]);
+
+        $this->assertCount(2, $company->activeUsers);
+    }
+
+    /**
+     * Test active scope.
+     */
+    public function test_active_scope(): void
+    {
+        Company::factory()->count(2)->active()->create();
+        Company::factory()->count(1)->inactive()->create();
+
+        $this->assertCount(2, Company::active()->get());
+    }
+
+    /**
+     * Test inactive scope.
+     */
+    public function test_inactive_scope(): void
+    {
+        Company::factory()->count(2)->active()->create();
+        Company::factory()->count(1)->inactive()->create();
+
+        $this->assertCount(1, Company::inactive()->get());
+    }
+
+    /**
+     * Test full address accessor.
+     */
+    public function test_full_address_accessor(): void
+    {
+        $company = Company::factory()->create([
+            'address' => '123 Main St',
+            'city' => 'Sample City',
+            'state' => 'State',
+            'postal_code' => '12345',
+            'country' => 'Country'
+        ]);
+
+        $expectedFullAddress = '123 Main St, Sample City, State, 12345, Country';
+
+        $this->assertEquals($expectedFullAddress, $company->fullAddress);
+    }
+}

--- a/modules/Lumasachi/tests/Unit/database/factories/CompanyFactoryTest.php
+++ b/modules/Lumasachi/tests/Unit/database/factories/CompanyFactoryTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Modules\Lumasachi\Tests\Unit\database\factories;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Modules\Lumasachi\app\Models\Company;
+
+final class CompanyFactoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that the factory creates a valid company.
+     */
+    public function test_factory_creates_valid_company(): void
+    {
+        $company = Company::factory()->create();
+
+        $this->assertInstanceOf(Company::class, $company);
+        $this->assertDatabaseHas('companies', [
+            'uuid' => $company->uuid,
+            'name' => $company->name,
+        ]);
+    }
+
+    /**
+     * Test that factory generates all required fields.
+     */
+    public function test_factory_generates_all_required_fields(): void
+    {
+        $company = Company::factory()->make();
+
+        $this->assertNotNull($company->name);
+        $this->assertNotNull($company->email);
+        $this->assertNotNull($company->phone);
+        $this->assertNotNull($company->address);
+        $this->assertNotNull($company->city);
+        $this->assertNotNull($company->state);
+        $this->assertNotNull($company->postal_code);
+        $this->assertNotNull($company->country);
+    }
+
+    /**
+     * Test optional fields.
+     */
+    public function test_optional_fields(): void
+    {
+        $optionalFields = [
+            'description',
+            'website',
+            'logo',
+            'tax_id',
+            'contact_person',
+            'contact_email',
+            'contact_phone',
+            'notes',
+            'settings'
+        ];
+
+        $fieldStats = [];
+        foreach ($optionalFields as $field) {
+            $fieldStats[$field] = ['filled' => 0, 'null' => 0];
+        }
+
+        // Generate multiple companies to test randomness of optional fields
+        $sampleSize = 50;
+        for ($i = 0; $i < $sampleSize; $i++) {
+            $company = Company::factory()->make();
+
+            foreach ($optionalFields as $field) {
+                if ($company->$field !== null) {
+                    $fieldStats[$field]['filled']++;
+                } else {
+                    $fieldStats[$field]['null']++;
+                }
+            }
+        }
+
+        // Verify that each optional field has both null and non-null values
+        foreach ($optionalFields as $field) {
+            $this->assertGreaterThan(
+                0,
+                $fieldStats[$field]['filled'],
+                "Optional field '{$field}' should sometimes be filled"
+            );
+            $this->assertGreaterThan(
+                0,
+                $fieldStats[$field]['null'],
+                "Optional field '{$field}' should sometimes be null"
+            );
+        }
+    }
+
+    /**
+     * Test that optional field probabilities are roughly correct.
+     */
+    public function test_optional_field_probabilities(): void
+    {
+        $expectedProbabilities = [
+            'description' => 0.8,
+            'website' => 0.7,
+            'logo' => 0.6,
+            'tax_id' => 0.7,
+            'contact_person' => 0.8,
+            'contact_email' => 0.8,
+            'contact_phone' => 0.8,
+            'notes' => 0.5,
+            'settings' => 0.9
+        ];
+
+        $sampleSize = 1000;
+        $fieldCounts = [];
+        foreach (array_keys($expectedProbabilities) as $field) {
+            $fieldCounts[$field] = 0;
+        }
+
+        // Generate many companies to test probability distribution
+        for ($i = 0; $i < $sampleSize; $i++) {
+            $company = Company::factory()->make();
+
+            foreach (array_keys($expectedProbabilities) as $field) {
+                if ($company->$field !== null) {
+                    $fieldCounts[$field]++;
+                }
+            }
+        }
+
+        // Check that actual probabilities are within acceptable range (±10%)
+        foreach ($expectedProbabilities as $field => $expectedProbability) {
+            $actualProbability = $fieldCounts[$field] / $sampleSize;
+            $tolerance = 0.1;
+
+            $this->assertGreaterThanOrEqual(
+                $expectedProbability - $tolerance,
+                $actualProbability,
+                "Field '{$field}' fill rate ({$actualProbability}) is too low (expected ~{$expectedProbability})"
+            );
+            $this->assertLessThanOrEqual(
+                $expectedProbability + $tolerance,
+                $actualProbability,
+                "Field '{$field}' fill rate ({$actualProbability}) is too high (expected ~{$expectedProbability})"
+            );
+        }
+    }
+
+    /**
+     * Test factory state methods for optional fields.
+     */
+    public function test_factory_state_methods_for_optional_fields(): void
+    {
+        // Test withoutWebsite state
+        $companyWithoutWebsite = Company::factory()->withoutWebsite()->make();
+        $this->assertNull($companyWithoutWebsite->website);
+
+        // Test withoutLogo state
+        $companyWithoutLogo = Company::factory()->withoutLogo()->make();
+        $this->assertNull($companyWithoutLogo->logo);
+
+        // Test minimal state - all optional fields should be null
+        $minimalCompany = Company::factory()->minimal()->make();
+        $this->assertNull($minimalCompany->description);
+        $this->assertNull($minimalCompany->website);
+        $this->assertNull($minimalCompany->logo);
+        $this->assertNull($minimalCompany->tax_id);
+        $this->assertNull($minimalCompany->contact_person);
+        $this->assertNull($minimalCompany->contact_email);
+        $this->assertNull($minimalCompany->contact_phone);
+        $this->assertNull($minimalCompany->notes);
+        $this->assertNull($minimalCompany->settings);
+
+        // Test complete state - all optional fields should be filled
+        $completeCompany = Company::factory()->complete()->make();
+        $this->assertNotNull($completeCompany->description);
+        $this->assertNotNull($completeCompany->notes);
+        $this->assertNotNull($completeCompany->settings);
+        $this->assertIsArray($completeCompany->settings);
+        $this->assertArrayHasKey('currency', $completeCompany->settings);
+        $this->assertArrayHasKey('date_format', $completeCompany->settings);
+        $this->assertArrayHasKey('time_format', $completeCompany->settings);
+    }
+
+}

--- a/modules/Lumasachi/tests/Unit/database/migrations/CreateCompanyTableTest.php
+++ b/modules/Lumasachi/tests/Unit/database/migrations/CreateCompanyTableTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Modules\Lumasachi\Tests\Unit\database\migrations;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class CreateCompanyTableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that the companies table exists after migration.
+     */
+    public function test_companies_table_exists(): void
+    {
+        $this->assertTrue(Schema::hasTable('companies'));
+    }
+
+    /**
+     * Test that the companies table has all required columns.
+     */
+    public function test_companies_table_has_all_required_columns(): void
+    {
+        $expectedColumns = [
+            'uuid',
+            'name',
+            'email',
+            'phone',
+            'address',
+            'city',
+            'state',
+            'postal_code',
+            'country',
+            'website',
+            'logo',
+            'tax_id',
+            'contact_person',
+            'contact_email',
+            'contact_phone',
+            'notes',
+            'description',
+            'is_active',
+            'settings',
+            'created_at',
+            'updated_at',
+        ];
+
+        foreach ($expectedColumns as $column) {
+            $this->assertTrue(
+                Schema::hasColumn('companies', $column),
+                "Column '{$column}' does not exist in companies table"
+            );
+        }
+    }
+}
+

--- a/modules/Lumasachi/tests/Unit/database/migrations/CreateUsersTableTest.php
+++ b/modules/Lumasachi/tests/Unit/database/migrations/CreateUsersTableTest.php
@@ -51,8 +51,6 @@ final class CreateUsersTableTest extends TestCase
             'password',
             'role',
             'phone_number',
-            'address',
-            'company',
             'is_active',
             'notes',
             'type',
@@ -76,7 +74,7 @@ final class CreateUsersTableTest extends TestCase
     public function test_users_table_column_types()
     {
         // Test string columns - PostgreSQL returns 'varchar' for string columns
-        $stringColumns = ['first_name', 'last_name', 'email', 'password', 'phone_number', 'address', 'company', 'type', 'preferences', 'remember_token'];
+        $stringColumns = ['first_name', 'last_name', 'email', 'password', 'phone_number', 'type', 'preferences', 'remember_token'];
         foreach ($stringColumns as $column) {
             $this->assertContains(
                 Schema::getColumnType('users', $column),
@@ -121,8 +119,6 @@ final class CreateUsersTableTest extends TestCase
             // These should accept null
             'email_verified_at' => null,
             'phone_number' => null,
-            'address' => null,
-            'company' => null,
             'notes' => null,
             'type' => null,
             'preferences' => null,
@@ -130,8 +126,6 @@ final class CreateUsersTableTest extends TestCase
 
         $this->assertNull($user->email_verified_at);
         $this->assertNull($user->phone_number);
-        $this->assertNull($user->address);
-        $this->assertNull($user->company);
         $this->assertNull($user->notes);
         $this->assertNull($user->type);
         $this->assertNull($user->preferences);
@@ -319,8 +313,6 @@ final class CreateUsersTableTest extends TestCase
             'password' => bcrypt('password'),
             'role' => UserRole::CUSTOMER->value,
             'phone_number' => '+1234567890',
-            'address' => '123 Main St, City, Country',
-            'company' => 'Acme Inc.',
             'is_active' => true,
             'notes' => 'VIP customer with special requirements',
             'type' => 'premium',
@@ -333,7 +325,6 @@ final class CreateUsersTableTest extends TestCase
             'first_name' => 'John',
             'last_name' => 'Doe',
             'role' => UserRole::CUSTOMER->value,
-            'company' => 'Acme Inc.',
             'is_active' => true,
         ]);
     }
@@ -360,8 +351,6 @@ final class CreateUsersTableTest extends TestCase
 
         // Check that nullable fields are indeed null
         $this->assertNull($user->phone_number);
-        $this->assertNull($user->address);
-        $this->assertNull($user->company);
         $this->assertNull($user->notes);
     }
 }

--- a/modules/Lumasachi/tests/Unit/database/seeders/CompanySeederTest.php
+++ b/modules/Lumasachi/tests/Unit/database/seeders/CompanySeederTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Modules\Lumasachi\Tests\Unit\database\seeders;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Modules\Lumasachi\app\Models\Company;
+use Modules\Lumasachi\database\seeders\CompanySeeder;
+
+final class CompanySeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that the seeder creates companies correctly.
+     */
+    public function test_seeder_creates_companies(): void
+    {
+        $this->seed(CompanySeeder::class);
+
+        $this->assertDatabaseHas('companies', ['name' => 'Acme Corporation']);
+        $this->assertDatabaseHas('companies', ['name' => 'TechVentures Inc.']);
+        $this->assertDatabaseHas('companies', ['name' => 'Global Solutions Ltd.']);
+        $this->assertDatabaseHas('companies', ['name' => 'StartUp Hub']);
+        $this->assertDatabaseHas('companies', ['name' => 'Legacy Enterprises']);
+
+        // Ensure that inactive companies exist
+        $this->assertDatabaseHas('companies', [
+            'name' => 'Legacy Enterprises',
+            'is_active' => false
+        ]);
+    }
+}
+

--- a/modules/Lumasachi/tests/Unit/database/seeders/DatabaseSeederTest.php
+++ b/modules/Lumasachi/tests/Unit/database/seeders/DatabaseSeederTest.php
@@ -88,7 +88,8 @@ final class DatabaseSeederTest extends TestCase
         // Test specific business customer
         $techCorp = User::where('email', 'robert@techcorp.com')->first();
         $this->assertNotNull($techCorp);
-        $this->assertEquals('Tech Corp Solutions', $techCorp->company);
+        // Since the seeder doesn't create a company for this user, we should check that it's a business type user
+        $this->assertEquals(UserType::BUSINESS->value, $techCorp->type);
         $this->assertStringContainsString('VIP customer', $techCorp->notes);
 
         // Test individual customers

--- a/tests/Feature/Models/UserCompanyRelationshipTest.php
+++ b/tests/Feature/Models/UserCompanyRelationshipTest.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use Tests\TestCase;
+use App\Models\User;
+use Modules\Lumasachi\app\Models\Company;
+use Modules\Lumasachi\app\Enums\UserRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+
+class UserCompanyRelationshipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test complete user-company workflow
+     */
+    #[Test]
+    public function it_checks_complete_user_company_workflow()
+    {
+        // Create a company
+        $company = Company::factory()->create([
+            'name' => 'Acme Corporation',
+            'email' => 'info@acme.com',
+            'is_active' => true
+        ]);
+
+        // Create multiple users with different roles for the company
+        $admin = User::factory()->create([
+            'company_id' => $company->uuid,
+            'role' => UserRole::ADMINISTRATOR,
+            'first_name' => 'John',
+            'last_name' => 'Admin'
+        ]);
+
+        $employee = User::factory()->create([
+            'company_id' => $company->uuid,
+            'role' => UserRole::EMPLOYEE,
+            'first_name' => 'Jane',
+            'last_name' => 'Employee'
+        ]);
+
+        $customer = User::factory()->create([
+            'company_id' => $company->uuid,
+            'role' => UserRole::CUSTOMER,
+            'first_name' => 'Bob',
+            'last_name' => 'Customer'
+        ]);
+
+        // Test that all users are associated with the company
+        $this->assertEquals($company->uuid, $admin->company_id);
+        $this->assertEquals($company->uuid, $employee->company_id);
+        $this->assertEquals($company->uuid, $customer->company_id);
+
+        // Test accessing company from users
+        $this->assertEquals('Acme Corporation', $admin->company->name);
+        $this->assertEquals('info@acme.com', $employee->company->email);
+        $this->assertTrue($customer->company->is_active);
+
+        // Test accessing users from company
+        $companyUsers = $company->users()->orderBy('first_name')->get();
+        $this->assertCount(3, $companyUsers);
+        $this->assertEquals('Bob', $companyUsers[0]->first_name);
+        $this->assertEquals('Jane', $companyUsers[1]->first_name);
+        $this->assertEquals('John', $companyUsers[2]->first_name);
+
+        // Test filtering users by role through company
+        $companyAdmins = $company->users()->where('role', UserRole::ADMINISTRATOR)->get();
+        $companyEmployees = $company->users()->where('role', UserRole::EMPLOYEE)->get();
+        $companyCustomers = $company->users()->where('role', UserRole::CUSTOMER)->get();
+
+        $this->assertCount(1, $companyAdmins);
+        $this->assertCount(1, $companyEmployees);
+        $this->assertCount(1, $companyCustomers);
+
+        $this->assertEquals('John', $companyAdmins->first()->first_name);
+        $this->assertEquals('Jane', $companyEmployees->first()->first_name);
+        $this->assertEquals('Bob', $companyCustomers->first()->first_name);
+    }
+
+    /**
+     * Test active users relationship
+     */
+    #[Test]
+    public function it_checks_company_active_users_relationship()
+    {
+        $company = Company::factory()->create();
+
+        // Create active users
+        $activeUsers = User::factory()->count(3)->create([
+            'company_id' => $company->uuid,
+            'is_active' => true
+        ]);
+
+        // Create inactive users
+        $inactiveUsers = User::factory()->count(2)->create([
+            'company_id' => $company->uuid,
+            'is_active' => false
+        ]);
+
+        // Test total users
+        $this->assertCount(5, $company->users);
+
+        // Test active users only
+        $this->assertCount(3, $company->activeUsers);
+
+        // Verify the active users are the correct ones
+        foreach ($activeUsers as $user) {
+            $this->assertTrue($company->activeUsers->contains($user));
+        }
+
+        // Verify inactive users are not included
+        foreach ($inactiveUsers as $user) {
+            $this->assertFalse($company->activeUsers->contains($user));
+        }
+    }
+
+    /**
+     * Test querying companies through users
+     */
+    #[Test]
+    public function it_checks_querying_companies_through_users()
+    {
+        // Create multiple companies
+        $techCompany = Company::factory()->create([
+            'name' => 'Tech Corp',
+            'city' => 'San Francisco'
+        ]);
+
+        $retailCompany = Company::factory()->create([
+            'name' => 'Retail Inc',
+            'city' => 'New York'
+        ]);
+
+        // Create users for each company
+        User::factory()->count(2)->create([
+            'company_id' => $techCompany->uuid
+        ]);
+
+        User::factory()->count(3)->create([
+            'company_id' => $retailCompany->uuid
+        ]);
+
+        // Query users with companies in specific cities
+        $sfUsers = User::whereHas('company', function ($query) {
+            $query->where('city', 'San Francisco');
+        })->with('company')->get();
+
+        $nyUsers = User::whereHas('company', function ($query) {
+            $query->where('city', 'New York');
+        })->with('company')->get();
+
+        $this->assertCount(2, $sfUsers);
+        $this->assertCount(3, $nyUsers);
+
+        // Verify all SF users belong to Tech Corp
+        foreach ($sfUsers as $user) {
+            $this->assertEquals('Tech Corp', $user->company->name);
+        }
+
+        // Verify all NY users belong to Retail Inc
+        foreach ($nyUsers as $user) {
+            $this->assertEquals('Retail Inc', $user->company->name);
+        }
+    }
+
+    /**
+     * Test complex queries with company relationship
+     */
+    #[Test]
+    public function it_checks_complex_queries_with_company_relationship()
+    {
+        // Create companies with different statuses
+        $activeCompany = Company::factory()->create([
+            'name' => 'Active Company',
+            'is_active' => true
+        ]);
+
+        $inactiveCompany = Company::factory()->create([
+            'name' => 'Inactive Company',
+            'is_active' => false
+        ]);
+
+        // Create administrators for active company
+        User::factory()->count(2)->create([
+            'company_id' => $activeCompany->uuid,
+            'role' => UserRole::ADMINISTRATOR,
+            'is_active' => true
+        ]);
+
+        // Create employees for active company
+        User::factory()->count(3)->create([
+            'company_id' => $activeCompany->uuid,
+            'role' => UserRole::EMPLOYEE,
+            'is_active' => true
+        ]);
+
+        // Create users for inactive company
+        User::factory()->count(2)->create([
+            'company_id' => $inactiveCompany->uuid,
+            'is_active' => true
+        ]);
+
+        // Query active administrators from active companies
+        $activeAdminsFromActiveCompanies = User::where('is_active', true)
+            ->where('role', UserRole::ADMINISTRATOR)
+            ->whereHas('company', function ($query) {
+                $query->where('is_active', true);
+            })
+            ->get();
+
+        $this->assertCount(2, $activeAdminsFromActiveCompanies);
+
+        // Query all users from inactive companies
+        $usersFromInactiveCompanies = User::whereHas('company', function ($query) {
+            $query->where('is_active', false);
+        })->get();
+
+        $this->assertCount(2, $usersFromInactiveCompanies);
+
+        // Count users per company using groupBy
+        $usersPerCompany = User::selectRaw('company_id, COUNT(*) as user_count')
+            ->groupBy('company_id')
+            ->whereNotNull('company_id')
+            ->get();
+
+        $this->assertCount(2, $usersPerCompany);
+        
+        $activeCompanyUserCount = $usersPerCompany->where('company_id', $activeCompany->uuid)->first();
+        $inactiveCompanyUserCount = $usersPerCompany->where('company_id', $inactiveCompany->uuid)->first();
+        
+        $this->assertEquals(5, $activeCompanyUserCount->user_count);
+        $this->assertEquals(2, $inactiveCompanyUserCount->user_count);
+    }
+
+    /**
+     * Test JSON responses include company data
+     */
+    #[Test]
+    public function it_checks_json_response_includes_company_data()
+    {
+        $company = Company::factory()->create([
+            'name' => 'Test Company',
+            'email' => 'test@example.com'
+        ]);
+
+        $user = User::factory()->create([
+            'company_id' => $company->uuid,
+            'first_name' => 'Test',
+            'last_name' => 'User'
+        ]);
+
+        // Load company relationship
+        $user->load('company');
+
+        // Convert to array (as would happen in API response)
+        $userData = $user->toArray();
+
+        // Assert company data is included
+        $this->assertArrayHasKey('company', $userData);
+        $this->assertEquals($company->uuid, $userData['company']['uuid']);
+        $this->assertEquals('Test Company', $userData['company']['name']);
+        $this->assertEquals('test@example.com', $userData['company']['email']);
+    }
+}

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Tests\TestCase;
+use App\Models\User;
+use Modules\Lumasachi\app\Models\Company;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use PHPUnit\Framework\Attributes\Test;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that user belongs to company relationship is properly defined
+     */
+    #[Test]
+    public function user_belongs_to_company_relationship()
+    {
+        $user = new User();
+
+        $this->assertInstanceOf(BelongsTo::class, $user->company());
+        $this->assertEquals('company_id', $user->company()->getForeignKeyName());
+        $this->assertEquals('uuid', $user->company()->getOwnerKeyName());
+    }
+
+    /**
+     * Test that user can be created without a company
+     */
+    #[Test]
+    public function user_can_be_created_without_company()
+    {
+        $user = User::factory()->create([
+            'company_id' => null
+        ]);
+
+        $this->assertNull($user->company_id);
+        $this->assertNull($user->company);
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'company_id' => null
+        ]);
+    }
+
+    /**
+     * Test that user can be associated with a company
+     */
+    #[Test]
+    public function user_can_be_associated_with_company()
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create([
+            'company_id' => $company->uuid
+        ]);
+
+        $this->assertEquals($company->uuid, $user->company_id);
+        $this->assertInstanceOf(Company::class, $user->company);
+        $this->assertEquals($company->uuid, $user->company->uuid);
+        $this->assertEquals($company->name, $user->company->name);
+    }
+
+    /**
+     * Test that user can access company attributes through relationship
+     */
+    #[Test]
+    public function user_can_access_company_attributes()
+    {
+        $companyData = [
+            'name' => 'Test Company',
+            'email' => 'test@company.com',
+            'phone' => '123-456-7890',
+            'address' => '123 Test St',
+            'city' => 'Test City',
+            'state' => 'TS',
+            'postal_code' => '12345',
+            'country' => 'Test Country',
+            'website' => 'https://testcompany.com'
+        ];
+
+        $company = Company::factory()->create($companyData);
+        $user = User::factory()->create([
+            'company_id' => $company->uuid
+        ]);
+
+        $this->assertEquals($companyData['name'], $user->company->name);
+        $this->assertEquals($companyData['email'], $user->company->email);
+        $this->assertEquals($companyData['phone'], $user->company->phone);
+        $this->assertEquals($companyData['address'], $user->company->address);
+        $this->assertEquals($companyData['city'], $user->company->city);
+        $this->assertEquals($companyData['state'], $user->company->state);
+        $this->assertEquals($companyData['postal_code'], $user->company->postal_code);
+        $this->assertEquals($companyData['country'], $user->company->country);
+        $this->assertEquals($companyData['website'], $user->company->website);
+    }
+
+    /**
+     * Test that multiple users can belong to the same company
+     */
+    #[Test]
+    public function multiple_users_can_belong_to_same_company()
+    {
+        $company = Company::factory()->create();
+        $users = User::factory()->count(3)->create([
+            'company_id' => $company->uuid
+        ]);
+
+        foreach ($users as $user) {
+            $this->assertEquals($company->uuid, $user->company_id);
+            $this->assertEquals($company->uuid, $user->company->uuid);
+        }
+
+        // Test from company perspective
+        $this->assertCount(3, $company->users);
+        $this->assertTrue($company->users->contains($users[0]));
+        $this->assertTrue($company->users->contains($users[1]));
+        $this->assertTrue($company->users->contains($users[2]));
+    }
+
+    /**
+     * Test that changing user's company updates the relationship
+     */
+    #[Test]
+    public function changing_users_company_updates_relationship()
+    {
+        $company1 = Company::factory()->create(['name' => 'Company 1']);
+        $company2 = Company::factory()->create(['name' => 'Company 2']);
+
+        $user = User::factory()->create([
+            'company_id' => $company1->uuid
+        ]);
+
+        // Initial state
+        $this->assertEquals($company1->uuid, $user->company_id);
+        $this->assertEquals('Company 1', $user->company->name);
+
+        // Update company
+        $user->update(['company_id' => $company2->uuid]);
+        $user->refresh();
+
+        // New state
+        $this->assertEquals($company2->uuid, $user->company_id);
+        $this->assertEquals('Company 2', $user->company->name);
+    }
+
+    /**
+     * Test that user's company can be removed
+     */
+    #[Test]
+    public function users_company_can_be_removed()
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create([
+            'company_id' => $company->uuid
+        ]);
+
+        // Initial state
+        $this->assertNotNull($user->company);
+
+        // Remove company
+        $user->update(['company_id' => null]);
+        $user->refresh();
+
+        // New state
+        $this->assertNull($user->company_id);
+        $this->assertNull($user->company);
+    }
+
+    /**
+     * Test eager loading of company relationship
+     */
+    #[Test]
+    public function eager_loading_company_relationship()
+    {
+        $company = Company::factory()->create();
+        User::factory()->count(3)->create([
+            'company_id' => $company->uuid
+        ]);
+
+        // Test that eager loading prevents N+1 queries
+        $users = User::with('company')->get();
+
+        foreach ($users as $user) {
+            // This should not trigger additional queries
+            $this->assertInstanceOf(Company::class, $user->company);
+            $this->assertEquals($company->name, $user->company->name);
+        }
+    }
+
+    /**
+     * Test that company_id is fillable
+     */
+    #[Test]
+    public function company_id_is_fillable()
+    {
+        $user = new User();
+        $fillable = $user->getFillable();
+
+        $this->assertContains('company_id', $fillable);
+    }
+
+    /**
+     * Test querying users by company
+     */
+    #[Test]
+    public function querying_users_by_company()
+    {
+        $company1 = Company::factory()->create();
+        $company2 = Company::factory()->create();
+
+        // Create users for company 1
+        User::factory()->count(2)->create([
+            'company_id' => $company1->uuid
+        ]);
+
+        // Create users for company 2
+        User::factory()->count(3)->create([
+            'company_id' => $company2->uuid
+        ]);
+
+        // Create users without company
+        User::factory()->count(1)->create([
+            'company_id' => null
+        ]);
+
+        // Query users by company
+        $company1Users = User::where('company_id', $company1->uuid)->get();
+        $company2Users = User::where('company_id', $company2->uuid)->get();
+        $usersWithoutCompany = User::whereNull('company_id')->get();
+
+        $this->assertCount(2, $company1Users);
+        $this->assertCount(3, $company2Users);
+        $this->assertCount(1, $usersWithoutCompany);
+    }
+
+    /**
+     * Test that deleting a company sets user's company_id to null (due to nullOnDelete)
+     */
+    #[Test]
+    public function deleting_company_sets_users_company_id_to_null()
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create([
+            'company_id' => $company->uuid
+        ]);
+
+        // Initial state
+        $this->assertEquals($company->uuid, $user->company_id);
+
+        // Delete company
+        $company->delete();
+        $user->refresh();
+
+        // User should still exist but company_id should be null
+        $this->assertNull($user->company_id);
+        $this->assertNull($user->company);
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'company_id' => null
+        ]);
+    }
+}


### PR DESCRIPTION
- Added `company_id` foreign key to the `users` table for establishing a relationship with the `companies` table.
- Introduced `Company` model and its corresponding factory for creating company instances.
- Updated `User` model to include `company` relationship and modified existing order-related methods to return type hints.
- Created `CompanySeeder` to seed initial company data and updated `DatabaseSeeder` to include it.
- Developed tests for `Company` model and its factory to ensure proper functionality and data integrity.
- Refactored user-related tests to accommodate the new company relationship.