### PR TITLE
chore: update Docker configuration for HTTPS support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,15 +12,19 @@ services:
         ports:
             - '${APP_PORT:-80}:80'
             - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+            - '443:443'
+            - '443:443/udp'
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
             XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
             XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
             IGNITION_LOCAL_SITES_PATH: '${PWD}'
-            SUPERVISOR_PHP_COMMAND: "/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --watch --server=frankenphp --host=0.0.0.0 --admin-port=2019 --port='${APP_PORT:-80}'"
+            #SUPERVISOR_PHP_COMMAND: "/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --watch --server=frankenphp --host=0.0.0.0 --admin-port=2019 --port='${APP_PORT:-80}'"
+            SUPERVISOR_PHP_COMMAND: "/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --host=localhost --port=443 --admin-port=2019 --https" # to be able to use HTTPS / HTTP2 / HTTP3
             XDG_CONFIG_HOME:  /var/www/html/config
             XDG_DATA_HOME:  /var/www/html/data
+
         volumes:
             - '.:/var/www/html'
         networks:


### PR DESCRIPTION
- Added support for HTTPS by exposing port 443 and enabling UDP.
- Updated the `SUPERVISOR_PHP_COMMAND` to allow HTTPS connections with the Octane server.
- Commented out the previous command for clarity and future reference.