### PR TITLE
fix: update email component references in order creation template

### DIFF
--- a/resources/views/mail/orders/created.blade.php
+++ b/resources/views/mail/orders/created.blade.php
@@ -1,4 +1,4 @@
-@component('mail::html.message')
+@component('mail::message')
 # New Order Created: #{{ $order->id }}
 
 A new order has been created.
@@ -11,7 +11,7 @@ A new order has been created.
 - Status: {{ $order->status->value }}
 - Priority: {{ $order->priority->value }}
 
-@component('mail::html.button', ['url' => route('orders.show', $order)])
+@component('mail::button', ['url' => route('orders.show', $order)])
 View Order
 @endcomponent
 


### PR DESCRIPTION
- Changed `@component('mail::html.message')` to `@component('mail::message')` for consistency with Laravel's mail component structure.
- Updated button component reference from `@component('mail::html.button', ...)` to `@component('mail::button', ...)` to align with the correct usage in email templates.