### PR TITLE
fix: update user route parameter to use email instead of user ID

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -24,7 +24,7 @@ Route::group(['prefix' => 'v1'], function () {
         ->middleware('auth:sanctum')
         ->name('logout');
 
-    Route::get('/user/{user}', function (Request $request, User $user) {
+    Route::get('/user/{user:email}', function (Request $request, User $user) {
         return response()->json([
             'user_id' => $user->id,
             'user_found' => true,


### PR DESCRIPTION
- Changed the route parameter in the user retrieval endpoint from `{user}` to `{user:email}` to allow fetching users by their email address.