### PR TITLE
refactor: update attachment preview method to return file response

### DIFF
--- a/app/Http/Controllers/AttachmentController.php
+++ b/app/Http/Controllers/AttachmentController.php
@@ -190,10 +190,16 @@ final class AttachmentController extends Controller
             ], 404);
         }
 
-        return response(Storage::temporaryUrl(
-            $attachment->file_path,
-            now()->addMinutes(5)
-        ));
+        // Get the file path
+        $filePath = Storage::disk('public')->path($attachment->file_path);
+
+        return response()->file(
+            $filePath,
+            [
+                'Content-Type' => $attachment->mime_type,
+                'Content-Disposition' => 'inline; filename="' . $attachment->file_name . '"'
+            ]
+        );
     }
 
     /**

--- a/tests/Feature/app/Http/Controllers/AttachmentControllerTest.php
+++ b/tests/Feature/app/Http/Controllers/AttachmentControllerTest.php
@@ -369,7 +369,8 @@ class AttachmentControllerTest extends TestCase
         $response = $this->get("/api/v1/attachments/{$attachment->uuid}/preview");
 
         $response->assertOk()
-            ->assertHeader('Content-Type', 'text/html; charset=UTF-8');
+            ->assertHeader('Content-Type', 'image/jpeg')
+            ->assertHeader('Content-Disposition', 'inline; filename="test-image.jpg"');
     }
 
     /**
@@ -395,7 +396,8 @@ class AttachmentControllerTest extends TestCase
         $response = $this->get("/api/v1/attachments/{$attachment->uuid}/preview");
 
         $response->assertOk()
-            ->assertHeader('Content-Type', 'text/html; charset=UTF-8');
+            ->assertHeader('Content-Type', 'application/pdf')
+            ->assertHeader('Content-Disposition', 'inline; filename="test-document.pdf"');
     }
 
     /**


### PR DESCRIPTION
- Modified the AttachmentController's preview method to return the file directly instead of a temporary URL, enhancing the response structure.
- Updated tests to assert correct Content-Type and Content-Disposition headers for image and PDF attachments.